### PR TITLE
fix content-length error for items router

### DIFF
--- a/internal/service/emby/playbackinfo.go
+++ b/internal/service/emby/playbackinfo.go
@@ -373,6 +373,7 @@ func LoadCacheItems(c *gin.Context) {
 	}
 	resJson := res.Data
 	defer func() {
+		c.Writer.Header().Del("Content-Length")
 		c.JSON(res.Code, resJson.Struct())
 	}()
 


### PR DESCRIPTION
解决了请求actor界面(/User/xx/Items/xx router)时有时会因为会遇上content-length mismatch错误的情况
具体表现为
curl: (18) transfer closed with 994 bytes remaining to read
<img width="637" alt="Clipboard 2025-04-25 16 58 14" src="https://github.com/user-attachments/assets/2aed6fbb-8bbb-4ff2-a994-9868d51cdf2d" />
