### PR TITLE
limit removing content-length behaviour to Person items

### DIFF
--- a/internal/service/emby/playbackinfo.go
+++ b/internal/service/emby/playbackinfo.go
@@ -380,7 +380,6 @@ func LoadCacheItems(c *gin.Context) {
 	}
 	resJson := res.Data
 	defer func() {
-		c.Writer.Header().Del("Content-Length")
 		c.JSON(res.Code, resJson.Struct())
 	}()
 
@@ -392,6 +391,9 @@ func LoadCacheItems(c *gin.Context) {
 	// 只处理特定类型的 Items 响应
 	itemType, _ := resJson.Attr("Type").String()
 	if !ValidCacheItemsTypeRegex.MatchString(itemType) {
+		if itemType == "Person" {
+			c.Writer.Header().Del("Content-Length")
+		}
 		return
 	}
 


### PR DESCRIPTION
之前在#76 打的补丁好像会导致iemc播放器异常返回，新的补丁把删除content-length的行为限制到仅演员界面触发。